### PR TITLE
fix: ignoring None paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,3 @@ select = ["ALL"]
     "T201", # `print` found
 ]
 
-[tool.uv.workspace]
-members = [
-    "mkslides",
-]

--- a/src/mkslides/serve.py
+++ b/src/mkslides/serve.py
@@ -66,7 +66,8 @@ def serve(
         server._setup_logging = lambda: None  # noqa: SLF001
 
         for path in paths_to_watch:
-            if path != None:
+            # E.g. if there is no config file present.
+            if path is not None:
                 logger.info(f"Watching: '{path}'")
                 server.watch(filepath=path.as_posix(), func=debounced_reload)
 

--- a/src/mkslides/serve.py
+++ b/src/mkslides/serve.py
@@ -66,8 +66,9 @@ def serve(
         server._setup_logging = lambda: None  # noqa: SLF001
 
         for path in paths_to_watch:
-            logger.info(f"Watching: '{path}'")
-            server.watch(filepath=path.as_posix(), func=debounced_reload)
+            if path != None:
+                logger.info(f"Watching: '{path}'")
+                server.watch(filepath=path.as_posix(), func=debounced_reload)
 
         server.serve(
             host=serve_config.dev_ip,


### PR DESCRIPTION
Hi !

I tried using mkslides and using this simple setup:

```
uv init
uv add mkslides
mkdir slides/
echo "# hello" > slides/slides.md
uv run mkslides serve
```

I got this error:

```bash

presentation on  main [?] is 📦 v0.1.0 via 🐍 v3.13.11 (presentation)
❯ mkslides serve
here
[05/07/26 13:52:05] INFO     Output directory: '/tmp/mkslides_nh6l0kbh'
                    INFO     Finished processing markdown in 0.03 seconds
                    INFO     Watching:
                             '/home/theo/Documents/modeling/presentation/slides'
                    INFO     Watching: 'None'
                    INFO     Removed '/tmp/mkslides_nh6l0kbh'
Traceback (most recent call last):
  File "/home/theo/Documents/modeling/presentation/.venv/bin/mkslides", line 10, in <module>
    sys.exit(cli())
             ~~~^^
  File "/home/theo/Documents/modeling/presentation/.venv/lib/python3.13/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/theo/Documents/modeling/presentation/.venv/lib/python3.13/site-packages/click/core.py", line 1435, in main
    rv = self.invoke(ctx)
  File "/home/theo/Documents/modeling/presentation/.venv/lib/python3.13/site-packages/click/core.py", line 1902, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/theo/Documents/modeling/presentation/.venv/lib/python3.13/site-packages/click/core.py", line 1298, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/theo/Documents/modeling/presentation/.venv/lib/python3.13/site-packages/click/core.py", line 853, in invoke
    return callback(*args, **kwargs)
  File "/home/theo/Documents/modeling/presentation/.venv/lib/python3.13/site-packages/mkslides/__main__.py", line 209, in serve_command
    serve(
    ~~~~~^
        config,
        ^^^^^^^
    ...<2 lines>...
        serve_config,
        ^^^^^^^^^^^^^
    )
    ^
  File "/home/theo/Documents/modeling/presentation/.venv/lib/python3.13/site-packages/mkslides/serve.py", line 70, in serve
    server.watch(filepath=path.as_posix(), func=debounced_reload)
                          ^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'as_posix'
```

This might be because of the internal config_path being None for some reason. To fix this, I just added a small fix to ignore None path. There might be a better solution but this works for me :) 